### PR TITLE
Add LawFirm entity and CRUD support

### DIFF
--- a/lawyer.api.lawyers.application/Common/MappingProfiles/LawFirmProfile.cs
+++ b/lawyer.api.lawyers.application/Common/MappingProfiles/LawFirmProfile.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using lawyer.api.lawyers.application.DTO;
+using lawyer.api.lawyers.application.UseCases.LawFirm.Create;
+using lawyer.api.lawyers.application.UseCases.LawFirm.Update;
+using lawyer.api.lawyers.domain;
+
+namespace lawyer.api.lawyers.application.Common.MappingProfiles;
+
+public class LawFirmProfile : Profile
+{
+    public LawFirmProfile()
+    {
+        CreateMap<LawFirmDto, LawFirm>().ReverseMap();
+        CreateMap<CreateLawFirmCommand, LawFirm>().ReverseMap();
+        CreateMap<UpdateLawFirmCommand, LawFirm>().ReverseMap();
+    }
+}

--- a/lawyer.api.lawyers.application/Contracts/Interfaces/Persistence/LawFirm/ILawFirmCommandRepository.cs
+++ b/lawyer.api.lawyers.application/Contracts/Interfaces/Persistence/LawFirm/ILawFirmCommandRepository.cs
@@ -1,0 +1,7 @@
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+
+public interface ILawFirmCommandRepository : ICommandRepository<domain.LawFirm>
+{
+}

--- a/lawyer.api.lawyers.application/Contracts/Interfaces/Persistence/LawFirm/ILawFirmQueryRepository.cs
+++ b/lawyer.api.lawyers.application/Contracts/Interfaces/Persistence/LawFirm/ILawFirmQueryRepository.cs
@@ -1,0 +1,7 @@
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+
+public interface ILawFirmQueryRepository : IQueryRepository<domain.LawFirm>
+{
+}

--- a/lawyer.api.lawyers.application/DTO/LawFirmDto.cs
+++ b/lawyer.api.lawyers.application/DTO/LawFirmDto.cs
@@ -1,0 +1,16 @@
+namespace lawyer.api.lawyers.application.DTO;
+
+public class LawFirmDto
+{
+    public Guid Id { get; set; }
+    public int IdCity { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public DateTime EntryDate { get; set; }
+    public bool Active { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string GoogleMapsAddress { get; set; } = string.Empty;
+    public string Biography { get; set; } = string.Empty;
+    public string SocialMediaLinks { get; set; } = string.Empty;
+}

--- a/lawyer.api.lawyers.application/DTO/LawFirmDto.cs
+++ b/lawyer.api.lawyers.application/DTO/LawFirmDto.cs
@@ -3,7 +3,7 @@ namespace lawyer.api.lawyers.application.DTO;
 public class LawFirmDto
 {
     public Guid Id { get; set; }
-    public int IdCity { get; set; }
+    public Guid IdCity { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Phone { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Create/CreateLawFirmCommand.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Create/CreateLawFirmCommand.cs
@@ -4,7 +4,7 @@ namespace lawyer.api.lawyers.application.UseCases.LawFirm.Create;
 
 public class CreateLawFirmCommand : IRequest<Guid>
 {
-    public int IdCity { get; set; }
+    public Guid IdCity { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Phone { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Create/CreateLawFirmCommand.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Create/CreateLawFirmCommand.cs
@@ -1,0 +1,17 @@
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.Create;
+
+public class CreateLawFirmCommand : IRequest<Guid>
+{
+    public int IdCity { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public DateTime EntryDate { get; set; }
+    public bool Active { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string GoogleMapsAddress { get; set; } = string.Empty;
+    public string Biography { get; set; } = string.Empty;
+    public string SocialMediaLinks { get; set; } = string.Empty;
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Create/CreateLawFirmCommandHandler.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Create/CreateLawFirmCommandHandler.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.Create;
+
+public class CreateLawFirmCommandHandler : IRequestHandler<CreateLawFirmCommand, Guid>
+{
+    private readonly ILawFirmCommandRepository _command;
+    private readonly IMapper _mapper;
+
+    public CreateLawFirmCommandHandler(
+        ILawFirmCommandRepository command,
+        IMapper mapper)
+    {
+        _command = command;
+        _mapper = mapper;
+    }
+
+    public async Task<Guid> Handle(CreateLawFirmCommand request, CancellationToken cancellationToken)
+    {
+        var entity = _mapper.Map<domain.LawFirm>(request);
+        await _command.CreateAsync(entity);
+        return entity.Id;
+    }
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Delete/DeleteLawFirmCommand.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Delete/DeleteLawFirmCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.Delete;
+
+public class DeleteLawFirmCommand : IRequest<Unit>
+{
+    public Guid Id { get; set; }
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Delete/DeleteLawFirmCommandHandler.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Delete/DeleteLawFirmCommandHandler.cs
@@ -1,0 +1,23 @@
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.Delete;
+
+public class DeleteLawFirmCommandHandler : IRequestHandler<DeleteLawFirmCommand, Unit>
+{
+    private readonly ILawFirmCommandRepository _command;
+    private readonly ILawFirmQueryRepository _query;
+
+    public DeleteLawFirmCommandHandler(ILawFirmCommandRepository command, ILawFirmQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Unit> Handle(DeleteLawFirmCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        await _command.DeleteAsync(entity);
+        return Unit.Value;
+    }
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/GetAll/GetAllLawFirmsQuery.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/GetAll/GetAllLawFirmsQuery.cs
@@ -1,0 +1,8 @@
+using lawyer.api.lawyers.application.DTO;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.GetAll;
+
+public class GetAllLawFirmsQuery : IRequest<List<LawFirmDto>>, IRequest<LawFirmDto>
+{
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/GetAll/GetAllLawFirmsQueryHandler.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/GetAll/GetAllLawFirmsQueryHandler.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using lawyer.api.lawyers.application.DTO;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.GetAll;
+
+public class GetAllLawFirmsQueryHandler : IRequestHandler<GetAllLawFirmsQuery, List<LawFirmDto>>
+{
+    private readonly ILawFirmQueryRepository _query;
+    private readonly IMapper _mapper;
+
+    public GetAllLawFirmsQueryHandler(
+        IMapper mapper,
+        ILawFirmQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<List<LawFirmDto>> Handle(GetAllLawFirmsQuery request, CancellationToken cancellationToken)
+    {
+        var entities = await _query.GetAllAsync();
+        return _mapper.Map<List<LawFirmDto>>(entities);
+    }
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/GetById/GetByIdLawFirmQuery.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/GetById/GetByIdLawFirmQuery.cs
@@ -1,0 +1,14 @@
+using lawyer.api.lawyers.application.DTO;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.GetById;
+
+public class GetByIdLawFirmQuery : IRequest<LawFirmDto>
+{
+    public GetByIdLawFirmQuery(Guid id)
+    {
+        Id = id;
+    }
+
+    public Guid Id { get; set; }
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/GetById/GetByIdLawFirmQueryHandler.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/GetById/GetByIdLawFirmQueryHandler.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using lawyer.api.lawyers.application.DTO;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.GetById;
+
+public class GetByIdLawFirmQueryHandler : IRequestHandler<GetByIdLawFirmQuery, LawFirmDto>
+{
+    private readonly IMapper _mapper;
+    private readonly ILawFirmQueryRepository _query;
+
+    public GetByIdLawFirmQueryHandler(
+        IMapper mapper,
+        ILawFirmQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<LawFirmDto> Handle(GetByIdLawFirmQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        return _mapper.Map<LawFirmDto>(entity);
+    }
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Update/UpdateLawFirmCommand.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Update/UpdateLawFirmCommand.cs
@@ -5,7 +5,7 @@ namespace lawyer.api.lawyers.application.UseCases.LawFirm.Update;
 public class UpdateLawFirmCommand : IRequest<Guid>
 {
     public Guid Id { get; set; }
-    public int IdCity { get; set; }
+    public Guid IdCity { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Phone { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Update/UpdateLawFirmCommand.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Update/UpdateLawFirmCommand.cs
@@ -1,0 +1,18 @@
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.Update;
+
+public class UpdateLawFirmCommand : IRequest<Guid>
+{
+    public Guid Id { get; set; }
+    public int IdCity { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public DateTime EntryDate { get; set; }
+    public bool Active { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string GoogleMapsAddress { get; set; } = string.Empty;
+    public string Biography { get; set; } = string.Empty;
+    public string SocialMediaLinks { get; set; } = string.Empty;
+}

--- a/lawyer.api.lawyers.application/UseCases/LawFirm/Update/UpdateLawFirmCommandHandler.cs
+++ b/lawyer.api.lawyers.application/UseCases/LawFirm/Update/UpdateLawFirmCommandHandler.cs
@@ -1,0 +1,39 @@
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using MediatR;
+
+namespace lawyer.api.lawyers.application.UseCases.LawFirm.Update;
+
+public class UpdateLawFirmCommandHandler : IRequestHandler<UpdateLawFirmCommand, Guid>
+{
+    private readonly ILawFirmCommandRepository _command;
+    private readonly ILawFirmQueryRepository _query;
+
+    public UpdateLawFirmCommandHandler(
+        ILawFirmCommandRepository command,
+        ILawFirmQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Guid> Handle(UpdateLawFirmCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        if (entity == null) throw new KeyNotFoundException($"The law firm with ID {request.Id} does not exist.");
+
+        entity.IdCity = request.IdCity;
+        entity.Name = request.Name;
+        entity.Phone = request.Phone;
+        entity.Email = request.Email;
+        entity.EntryDate = request.EntryDate;
+        entity.Active = request.Active;
+        entity.Address = request.Address;
+        entity.GoogleMapsAddress = request.GoogleMapsAddress;
+        entity.Biography = request.Biography;
+        entity.SocialMediaLinks = request.SocialMediaLinks;
+        entity.DateModified = DateTime.UtcNow;
+
+        await _command.UpdateAsync(entity);
+        return entity.Id;
+    }
+}

--- a/lawyer.api.lawyers.datastore.mssql/DatabaseContext/LawyersContext.cs
+++ b/lawyer.api.lawyers.datastore.mssql/DatabaseContext/LawyersContext.cs
@@ -13,6 +13,7 @@ public class LawyersContext : DbContext
     public DbSet<LawyerEntity> Layers { get; set; }
     public DbSet<AcademicInfoEntity> AcademicInfos { get; set; }
     public DbSet<ExampleEntity> Examples { get; set; }
+    public DbSet<LawFirmEntity> LawFirms { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/lawyer.api.lawyers.datastore.mssql/DatabaseContext/LawyersContext.cs
+++ b/lawyer.api.lawyers.datastore.mssql/DatabaseContext/LawyersContext.cs
@@ -10,7 +10,7 @@ public class LawyersContext : DbContext
     {
     }
 
-    public DbSet<LawyerEntity> Layers { get; set; }
+    public DbSet<LawyerEntity> Lawyers { get; set; }
     public DbSet<AcademicInfoEntity> AcademicInfos { get; set; }
     public DbSet<ExampleEntity> Examples { get; set; }
     public DbSet<LawFirmEntity> LawFirms { get; set; }

--- a/lawyer.api.lawyers.datastore.mssql/Migrations/LawyersContextModelSnapshot.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Migrations/LawyersContextModelSnapshot.cs
@@ -22,6 +22,113 @@ namespace lawyer.api.lawyers.datastore.mssql.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
+            modelBuilder.Entity("lawyer.api.lawyers.datastore.mssql.Model.AcademicInfoEntity", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("DateCreated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime?>("DateModified")
+                        .HasColumnType("datetime2");
+
+                    b.Property<Guid>("LawyerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Url")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("AcademicInfo");
+                });
+
+            modelBuilder.Entity("lawyer.api.lawyers.datastore.mssql.Model.ExampleEntity", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("DateCreated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime?>("DateModified")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("PropertyOne")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("PropertyTwo")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Examples");
+                });
+
+            modelBuilder.Entity("lawyer.api.lawyers.datastore.mssql.Model.LawFirmEntity", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Address")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Biography")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime?>("DateCreated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime?>("DateModified")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime>("EntryDate")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("GoogleMapsAddress")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("IdCity")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Phone")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("SocialMediaLinks")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("LawFirms");
+                });
+
             modelBuilder.Entity("lawyer.api.lawyers.datastore.mssql.Model.LawyerEntity", b =>
                 {
                     b.Property<Guid>("Id")
@@ -69,67 +176,11 @@ namespace lawyer.api.lawyers.datastore.mssql.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid>("User")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
                     b.HasKey("Id");
 
-                b.ToTable("Lawyers");
-            });
-
-            modelBuilder.Entity("lawyer.api.lawyers.datastore.mssql.Model.AcademicInfoEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("LawyerId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Url")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("DateCreated")
-                        .HasColumnType("datetime2");
-
-                    b.Property<DateTime?>("DateModified")
-                        .HasColumnType("datetime2");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("LawyerId");
-
-                    b.ToTable("AcademicInfo");
-                });
-
-            modelBuilder.Entity("lawyer.api.lawyers.datastore.mssql.Model.ExampleEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("PropertyOne")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("PropertyTwo")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("DateCreated")
-                        .HasColumnType("datetime2");
-
-                    b.Property<DateTime?>("DateModified")
-                        .HasColumnType("datetime2");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Examples");
+                    b.ToTable("Lawyers");
                 });
 #pragma warning restore 612, 618
         }

--- a/lawyer.api.lawyers.datastore.mssql/Model/AcademicInfo.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/AcademicInfo.cs
@@ -6,6 +6,7 @@ namespace lawyer.api.lawyers.datastore.mssql.Model;
 [Table("AcademicInfo")]
 public class AcademicInfoEntity : EFEntity
 {
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid LawyerId { get; set; }
     public string Name { get; set; }
     public string Url { get; set; }

--- a/lawyer.api.lawyers.datastore.mssql/Model/Example.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/Example.cs
@@ -6,6 +6,7 @@ namespace lawyer.api.lawyers.datastore.mssql.Model;
 [Table("Examples")]
 public class ExampleEntity : EFEntity
 {
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public string PropertyOne { get; set; }
     public string PropertyTwo { get; set; }
 }

--- a/lawyer.api.lawyers.datastore.mssql/Model/LawFirmEntity.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/LawFirmEntity.cs
@@ -6,7 +6,8 @@ namespace lawyer.api.lawyers.datastore.mssql.Model;
 [Table("LawFirms")]
 public class LawFirmEntity : EFEntity
 {
-    public int IdCity { get; set; }
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid IdCity { get; set; }
     public string Name { get; set; }
     public string Phone { get; set; }
     public string Email { get; set; }

--- a/lawyer.api.lawyers.datastore.mssql/Model/LawFirmEntity.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/LawFirmEntity.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using lawyer.api.lawyers.datastore.mssql.Model.Common;
+
+namespace lawyer.api.lawyers.datastore.mssql.Model;
+
+[Table("LawFirms")]
+public class LawFirmEntity : EFEntity
+{
+    public int IdCity { get; set; }
+    public string Name { get; set; }
+    public string Phone { get; set; }
+    public string Email { get; set; }
+    public DateTime EntryDate { get; set; }
+    public bool Active { get; set; }
+    public string Address { get; set; }
+    public string GoogleMapsAddress { get; set; }
+    public string Biography { get; set; }
+    public string SocialMediaLinks { get; set; }
+}

--- a/lawyer.api.lawyers.datastore.mssql/Model/LawyerEntity.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/LawyerEntity.cs
@@ -6,7 +6,7 @@ namespace lawyer.api.lawyers.datastore.mssql.Model;
 [Table("Lawyers")]
 public class LawyerEntity : EFEntity
 {
-    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid User { get; set; }
 
     public Guid Studio { get; set; }

--- a/lawyer.api.lawyers.datastore.mssql/Model/LawyerEntity.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/LawyerEntity.cs
@@ -8,7 +8,6 @@ public class LawyerEntity : EFEntity
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid User { get; set; }
-
     public Guid Studio { get; set; }
     public Guid City { get; set; }
     public string Name { get; set; }

--- a/lawyer.api.lawyers.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
@@ -11,5 +11,6 @@ public class ApplicationMappingProfile : Profile
         CreateMap<Lawyer, LawyerEntity>().ReverseMap();
         CreateMap<AcademicInfo, AcademicInfoEntity>().ReverseMap();
         CreateMap<Example, ExampleEntity>().ReverseMap();
+        CreateMap<LawFirm, LawFirmEntity>().ReverseMap();
     }
 }

--- a/lawyer.api.lawyers.datastore.mssql/PersistenceServiceRegistration.cs
+++ b/lawyer.api.lawyers.datastore.mssql/PersistenceServiceRegistration.cs
@@ -1,12 +1,14 @@
 using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.Lawyer;
 using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.AcademicInfo;
 using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.Example;
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
 using lawyer.api.lawyers.datastore.mssql.DatabaseContext;
 using lawyer.api.lawyers.datastore.mssql.Model.MappingProfile;
 using lawyer.api.lawyers.datastore.mssql.Repositories.Lawyer;
 using lawyer.api.lawyers.datastore.mssql.Repositories.Laywer;
 using lawyer.api.lawyers.datastore.mssql.Repositories.AcademicInfo;
 using lawyer.api.lawyers.datastore.mssql.Repositories.Example;
+using lawyer.api.lawyers.datastore.mssql.Repositories.LawFirm;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +29,8 @@ public static class PersistenceServiceRegistration
         services.AddScoped<IAcademicInfoQueryRepository, AcademicInfoQueryRepository>();
         services.AddScoped<IExampleCommandRepository, ExampleCommandRepository>();
         services.AddScoped<IExampleQueryRepository, ExampleQueryRepository>();
+        services.AddScoped<ILawFirmCommandRepository, LawFirmCommandRepository>();
+        services.AddScoped<ILawFirmQueryRepository, LawFirmQueryRepository>();
 
         return services;
     }}

--- a/lawyer.api.lawyers.datastore.mssql/Repositories/LawFirm/LawFirmCommandRepository.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Repositories/LawFirm/LawFirmCommandRepository.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using lawyer.api.lawyers.datastore.mssql.DatabaseContext;
+using lawyer.api.lawyers.datastore.mssql.Model;
+using lawyer.api.lawyers.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.lawyers.datastore.mssql.Repositories.LawFirm;
+
+public class LawFirmCommandRepository : CommandRepository<domain.LawFirm, LawFirmEntity>, ILawFirmCommandRepository
+{
+    private readonly IMapper _mapper;
+
+    public LawFirmCommandRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}

--- a/lawyer.api.lawyers.datastore.mssql/Repositories/LawFirm/LawFirmQueryRepository.cs
+++ b/lawyer.api.lawyers.datastore.mssql/Repositories/LawFirm/LawFirmQueryRepository.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using lawyer.api.lawyers.application.Contracts.Interfaces.Persistence.LawFirm;
+using lawyer.api.lawyers.datastore.mssql.DatabaseContext;
+using lawyer.api.lawyers.datastore.mssql.Model;
+using lawyer.api.lawyers.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.lawyers.datastore.mssql.Repositories.LawFirm;
+
+public class LawFirmQueryRepository : QueryRepository<domain.LawFirm, LawFirmEntity>, ILawFirmQueryRepository
+{
+    private readonly IMapper _mapper;
+
+    public LawFirmQueryRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}

--- a/lawyer.api.lawyers.domain/LawFirm.cs
+++ b/lawyer.api.lawyers.domain/LawFirm.cs
@@ -1,0 +1,17 @@
+using lawyer.api.lawyers.domain.Common;
+
+namespace lawyer.api.lawyers.domain;
+
+public class LawFirm : BaseEntity
+{
+    public int IdCity { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public DateTime EntryDate { get; set; }
+    public bool Active { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string GoogleMapsAddress { get; set; } = string.Empty;
+    public string Biography { get; set; } = string.Empty;
+    public string SocialMediaLinks { get; set; } = string.Empty;
+}

--- a/lawyer.api.lawyers.domain/LawFirm.cs
+++ b/lawyer.api.lawyers.domain/LawFirm.cs
@@ -4,7 +4,7 @@ namespace lawyer.api.lawyers.domain;
 
 public class LawFirm : BaseEntity
 {
-    public int IdCity { get; set; }
+    public Guid IdCity { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Phone { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;

--- a/lawyer.api.lawyers.webapi/Controllers/LawFirmController.cs
+++ b/lawyer.api.lawyers.webapi/Controllers/LawFirmController.cs
@@ -1,0 +1,70 @@
+using lawyer.api.lawyers.application.DTO;
+using lawyer.api.lawyers.application.UseCases.LawFirm.Create;
+using lawyer.api.lawyers.application.UseCases.LawFirm.Delete;
+using lawyer.api.lawyers.application.UseCases.LawFirm.GetAll;
+using lawyer.api.lawyers.application.UseCases.LawFirm.GetById;
+using lawyer.api.lawyers.application.UseCases.LawFirm.Update;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace lawyer.api.lawyers.webapi.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class LawFirmController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public LawFirmController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<LawFirmDto>>> Get()
+    {
+        var entities = await _mediator.Send(new GetAllLawFirmsQuery());
+        return Ok(entities);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<LawFirmDto>> Get(Guid id)
+    {
+        var entity = await _mediator.Send(new GetByIdLawFirmQuery(id));
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Post([FromBody] CreateLawFirmCommand command)
+    {
+        var id = await _mediator.Send(command);
+        var url = Url.Action(nameof(Get), new { id });
+        return Created(url, id);
+    }
+
+    [HttpPut]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Put([FromBody] UpdateLawFirmCommand command)
+    {
+        if (command.Id == Guid.Empty)
+            return BadRequest("The provided ID is not valid.");
+
+        var updatedId = await _mediator.Send(command);
+        return Ok(updatedId);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(404)]
+    public async Task<ActionResult> Delete(Guid id)
+    {
+        var command = new DeleteLawFirmCommand { Id = id };
+        await _mediator.Send(command);
+        return NoContent();
+    }
+}


### PR DESCRIPTION
## Summary
- create `LawFirm` domain entity
- add DTO and CRUD use cases for `LawFirm`
- implement EF entity and repositories
- register new repositories in persistence layer
- expose CRUD endpoints via `LawFirmController`
- update mapping profile and context

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688928ce4cfc8323aeb393d90ac6ad47